### PR TITLE
Observer abort None/LowerPriority condition bug fix

### DIFF
--- a/src/BranchNode.ts
+++ b/src/BranchNode.ts
@@ -64,7 +64,8 @@ export default class BranchNode extends Node {
         } else {
           const activeNode = registryLookUp(this.nodes[startingIndex]);
           activeNode.abort(blackboard, { registryLookUp, lastRun: lastRunStates[startingIndex] });
-          startingIndex = 0;
+          rerun = false
+          startingIndex = 0
         }
       }
 


### PR DESCRIPTION
Fixed a bug where rerun was not reset back to false after abort.